### PR TITLE
Atualiza versão do endpoint de Notificações

### DIFF
--- a/includes/class-wc-pagseguro-api.php
+++ b/includes/class-wc-pagseguro-api.php
@@ -102,7 +102,7 @@ class WC_PagSeguro_API {
 	 * @return string.
 	 */
 	protected function get_notification_url() {
-		return 'https://ws.' . $this->get_environment() . 'pagseguro.uol.com.br/v2/transactions/notifications/';
+		return 'https://ws.' . $this->get_environment() . 'pagseguro.uol.com.br/v3/transactions/notifications/';
 	}
 
 	/**

--- a/includes/class-wc-pagseguro-gateway.php
+++ b/includes/class-wc-pagseguro-gateway.php
@@ -633,6 +633,7 @@ class WC_PagSeguro_Gateway extends WC_Payment_Gateway {
 
 						break;
 					case 7:
+					case 8:
 						$order->update_status( 'cancelled', __( 'PagSeguro: Payment canceled.', 'woocommerce-pagseguro' ) );
 
 						if ( function_exists( 'wc_increase_stock_levels' ) ) {
@@ -640,7 +641,10 @@ class WC_PagSeguro_Gateway extends WC_Payment_Gateway {
 						}
 
 						break;
+					case 9:
+						$order->add_order_note( __( 'PagSeguro: The customer filed a chargeback request with the credit card company.', 'woocommerce-pagseguro' ) );
 
+						break;
 					default:
 						break;
 				}

--- a/languages/woocommerce-pagseguro.pot
+++ b/languages/woocommerce-pagseguro.pot
@@ -558,6 +558,12 @@ msgstr ""
 msgid "PagSeguro: Payment canceled."
 msgstr ""
 
+#: includes/class-wc-pagseguro-gateway.php:645
+msgid ""
+"PagSeguro: The customer filed a chargeback request with the credit card "
+"company."
+msgstr ""
+
 #: includes/class-wc-pagseguro.php:63
 msgid "Settings"
 msgstr ""


### PR DESCRIPTION
Recentemente minha loja passou por dois estranhos casos de consulta por notificações de mudanças de status divergentes das verificadas via painel do PagSeguro. Descrevi um pouco melhor em #122.
Ao buscar esclarecimentos com a empresa fui informado sobre a mudança da versão do endpoint de Notificações (ver [documentação oficial](https://dev.pagseguro.uol.com.br/docs/api-notificacao-v1#a-nameconsultando-uma-notificacao-de-transacaoaconsultando-uma-notifica%C3%A7%C3%A3o-de-transa%C3%A7%C3%A3o)).

Resumindo, o antigo endpoint `v2/transactions/notifications/` quando consultado não exibe os reais status 9 e 8 mas sim 3 e 4, respectivamente.

Junto com esta mudança criei uma sugestão de tratamento para os novos status 8 e 9 ainda não contemplados pelo plugin.